### PR TITLE
Open a file specified on the command line

### DIFF
--- a/Astrolabe/Form1.cs
+++ b/Astrolabe/Form1.cs
@@ -21,6 +21,35 @@ namespace Astrolabe
         {
             InitializeComponent();
         }
+        public Form1(String fileNameAndPath)
+        {
+            InitializeComponent();
+            openFile(fileNameAndPath);
+            
+        }
+        /// <summary>
+        /// Runs the necessary steps to open the file with path 
+        /// specified in the argument. 
+        /// Provides a single method for logic that may be called 
+        /// from several other methods.
+        /// </summary>
+        /// <param name="fileNameAndPath"></param>
+        private void openFile(String fileNameAndPath)
+        {
+            // Get the configuration item from the file specified by the user.
+            FileInfo fileInfo = new FileInfo(fileNameAndPath);
+            configItem = new ConfigurationItem(fileInfo.DirectoryName, fileInfo.Name.Replace(".config", ""), true);
+
+            // Load the data from the file.
+            nameLabel.Text = configItem.Name;
+            valueTextBox.Text = configItem.Value;
+
+            openFileLabel.Visible = false;
+            openFileButton.Visible = false;
+            saveToolStripMenuItem.Enabled = true;
+            saveAsToolStripMenuItem.Enabled = true;
+            closeToolStripMenuItem.Enabled = true;
+        }
 
         private void newToolStripMenuItem_Click(object sender, EventArgs e)
         {
@@ -31,19 +60,7 @@ namespace Astrolabe
 
             if (saveDialog.ShowDialog() == DialogResult.OK)
             {
-                // Get the configuration item from the file specified by the user.
-                FileInfo fileInfo = new FileInfo(saveDialog.FileName);
-                configItem = new ConfigurationItem(fileInfo.DirectoryName, fileInfo.Name.Replace(".config", ""), true);
-
-                // Load the data from the file.
-                nameLabel.Text = configItem.Name;
-                valueTextBox.Text = configItem.Value;
-
-                openFileLabel.Visible = false;
-                openFileButton.Visible = false;
-                saveToolStripMenuItem.Enabled = true;
-                saveAsToolStripMenuItem.Enabled = true;
-                closeToolStripMenuItem.Enabled = true;
+                openFile(saveDialog.FileName);
             }
         }
 
@@ -56,19 +73,7 @@ namespace Astrolabe
 
             if (openDialog.ShowDialog() == DialogResult.OK)
             {
-                // Get the configuration item from the file specified by the user.
-                FileInfo fileInfo = new FileInfo(openDialog.FileName);
-                configItem = new ConfigurationItem(fileInfo.DirectoryName, fileInfo.Name.Replace(".config", ""), true);
-
-                // Load the data from the file.
-                nameLabel.Text = configItem.Name;
-                valueTextBox.Text = configItem.Value;
-
-                openFileLabel.Visible = false;
-                openFileButton.Visible = false;
-                saveToolStripMenuItem.Enabled = true;
-                saveAsToolStripMenuItem.Enabled = true;
-                closeToolStripMenuItem.Enabled = true;
+                openFile(openDialog.FileName);
             }
         }
 

--- a/Astrolabe/Program.cs
+++ b/Astrolabe/Program.cs
@@ -12,11 +12,51 @@ namespace Astrolabe
         /// The main entry point for the application.
         /// </summary>
         [STAThread]
-        static void Main()
+        static int Main(string[] args)
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
-            Application.Run(new Form1());
+            switch (args.Length)
+            {
+                case 0:
+                    //Open program without specifying a file.
+                    Application.Run(new Form1());
+                    break;
+                case 1:
+                    //Possibly a single file specified on command line
+                    //Make sure it's a file, then open it.
+                    if (verifyFile(args[0])) {
+                        Application.Run(new Form1(args[0]));
+                    } else {
+                        Application.Run(new Form1());
+                    }
+                    break;
+
+                default:
+                    //Invalid number of files specified, ignore CLI input
+                    Application.Run(new Form1());
+                    break;
+            }
+            return 0;
+        }
+        /// <summary>
+        /// Perform checks against the string supplied on the command-
+        /// line to verify that it represents the path to a suitable
+        /// file, where suitable is currently defined as being a
+        /// regular file. Possibly expand the check here to exclude
+        /// too-large files, or files for which we have no read perms.
+        /// </summary>
+        /// <returns>Whether or not the specified argument represents the path to a suitable file</returns>
+        public static bool verifyFile(String filePath)
+        {
+            if (System.IO.File.Exists(filePath))
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
Added aCLI interface to allow Astrolabe to open a file that has its name and path specified on the command line.
Allows you to associate Astrolabe with the 'open' action of .config files in Windows so you can just double-click the .config file to open it in Astrolabe.
